### PR TITLE
Add ability to show/set fan_speed and water_grade

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The name of vacuum is based on the MQTT entity, with the `vacuum.` prefix remove
 | show_segments | boolean | true | Draw the floor segments on the map
 | show_status | boolean | true | Show the status of vacuum_entity
 | show_battery_level | boolean | true | Show the battery level of vacuum_entity
+| show_fan_speed | boolean | true | Show the fan speed of vacuum_entity
 | show_start_button | boolean | true | Show the start button for vacuum_entity
 | show_pause_button | boolean | true | Show the pause button for vacuum_entity
 | show_stop_button | boolean | true | Show the stop button for vacuum_entity

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The name of vacuum is based on the MQTT entity, with the `vacuum.` prefix remove
 | show_status | boolean | true | Show the status of vacuum_entity
 | show_battery_level | boolean | true | Show the battery level of vacuum_entity
 | show_fan_speed | boolean | true | Show the fan speed of vacuum_entity
+| show_water_grade | boolean | true | Show the water grade entity named `select.*_water_grade` where * is the name of the vacuum in MQTT
 | show_start_button | boolean | true | Show the start button for vacuum_entity
 | show_pause_button | boolean | true | Show the pause button for vacuum_entity
 | show_stop_button | boolean | true | Show the stop button for vacuum_entity

--- a/valetudo-map-card.js
+++ b/valetudo-map-card.js
@@ -565,6 +565,7 @@ class ValetudoMapCard extends HTMLElement {
     // Info show settings
     if (this._config.show_status === undefined) this._config.show_status = true;
     if (this._config.show_battery_level === undefined) this._config.show_battery_level = true;
+    if (this._config.show_fan_speed === undefined) this._config.show_fan_speed = true;
 
     // Show button settings
     if (this._config.show_start_button === undefined) this._config.show_start_button = true;
@@ -900,6 +901,42 @@ class ValetudoMapCard extends HTMLElement {
           batteryData.appendChild(batteryIcon);
           batteryData.appendChild(batteryText);
           this.infoBox.appendChild(batteryData);
+        }
+        
+        if (infoEntity && infoEntity.attributes && infoEntity.attributes.fan_speed && infoEntity.attributes.fan_speed_list && this._config.show_fan_speed) {
+          const fanSpeedMenuButton = document.createElement('paper-menu-button');
+          fanSpeedMenuButton.slot = "dropdown-trigger";
+          fanSpeedMenuButton.addEventListener('click', (event) => { event.stopPropagation() });
+
+          const fanSpeedListbox = document.createElement('paper-listbox');
+          fanSpeedListbox.slot = "dropdown-content";
+          fanSpeedListbox.setAttribute("selected", infoEntity.attributes.fan_speed);
+          fanSpeedListbox.setAttribute("attr-for-selected", "value");
+          fanSpeedListbox.addEventListener('click', (event) => {
+            let requestData = { entity_id: this.getVacuumEntityName(this._config.vacuum), fan_speed: event.target.getAttribute("value")};
+            this._hass.callService('vacuum', 'set_fan_speed', requestData).then();
+          });
+          infoEntity.attributes.fan_speed_list.forEach(speed => {
+            let speedItem = document.createElement('paper-item');
+            speedItem.setAttribute("value", speed);
+            speedItem.innerHTML = speed[0].toUpperCase() + speed.substring(1);
+            fanSpeedListbox.appendChild(speedItem);
+          })
+
+          const fanSpeedButton = document.createElement('paper-button');
+          fanSpeedButton.slot = "dropdown-trigger";
+          fanSpeedButton.style.display = "flex"
+          fanSpeedButton.style.alignItems = "center"
+          const fanSpeedIcon = document.createElement('ha-icon');
+          const fanSpeedText = document.createElement('span');
+          fanSpeedIcon.icon = "mdi:fan";
+          fanSpeedText.innerHTML = " " + infoEntity.attributes.fan_speed[0].toUpperCase() + infoEntity.attributes.fan_speed.substring(1);
+          fanSpeedButton.appendChild(fanSpeedIcon);
+          fanSpeedButton.appendChild(fanSpeedText);
+          
+          fanSpeedMenuButton.appendChild(fanSpeedButton);
+          fanSpeedMenuButton.appendChild(fanSpeedListbox);
+          this.infoBox.appendChild(fanSpeedMenuButton);
         }
 
         this.controlFlexBox = document.createElement('div');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26947075/147970884-ec3a6d08-32c5-49e4-8cda-ad132f287de1.png)

Clicking on the fan speed will show a dropdown and call the `vacuum.set_fan_speed` service after selection:

![image](https://user-images.githubusercontent.com/26947075/147891082-59725468-ab14-4495-a7ef-992309ec20a5.png)

Clicking on the water grade will show a dropdown and call the `select.select_option` service after selection:

![image](https://user-images.githubusercontent.com/26947075/147971042-61bf37c6-4c7a-4aa4-ab46-d77a14928d3e.png)

The water grade assumes the naming pattern of `"select." + vacuum_name + "_water_grade"`, which is the default when generated by mqtt (at least for my s5 max)
