### PR TITLE
Avoid duplicate element definition if already defined

### DIFF
--- a/src/valetudo-map-card.js
+++ b/src/valetudo-map-card.js
@@ -1048,12 +1048,15 @@ class ValetudoMapCard extends HTMLElement {
     }
 }
 
-customElements.define("valetudo-map-card", ValetudoMapCard);
+let componentName = "valetudo-map-card";
+if (!customElements.get(componentName)) {
+    customElements.define(componentName, ValetudoMapCard);
 
-window.customCards = window.customCards || [];
-window.customCards.push({
-    type: "valetudo-map-card",
-    name: "Valetudo Map Card",
-    preview: false,
-    description: "Display the Map data of your Valetudo-enabled robot",
-});
+    window.customCards = window.customCards || [];
+    window.customCards.push({
+        type: componentName,
+        name: "Valetudo Map Card",
+        preview: false,
+        description: "Display the Map data of your Valetudo-enabled robot",
+    });
+}


### PR DESCRIPTION
I realized that this card produces error messages in my javascript console because it tries to define the element `valetudo-map-card` a second time. Looking at my network tab in Firefox I can see, that it is once loaded from `/local/community/lovelace-valetudo-map-card/valetudo-map-card.js` and a second time from `/hacsfiles/lovelace-valetudo-map-card/valetudo-map-card.js`.

As far as I can tell this is [wanted behavior](https://hacs.xyz/docs/categories/plugins/#custom-view-hacsfiles) of home-assistant/hacs. I also checked another popular lovelace card and there I found the same approach: https://github.com/piitaya/lovelace-mushroom/blob/48db88d906be1301da6d2bfe2b259a704399c225/src/cards/chips-card/chips/conditional-chip.ts#L61-L64

This PR implements a check before the element gets defined and skips the step if already present.