### PR TITLE
Add "npm run dev" for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ Custom buttons can be added to this card when vacuum_entity is set. Each custom 
 | icon         | string | mdi:radiobox-blank | The icon that will represent the custom button           
 | text         | string | ""                 | Optional text to display next to the icon                
 
+## Development
+
+1. Run Rollup in watch mode
+
+    ```sh
+    npm run dev
+    ```
+
+2. Enable **Advanced Mode** in your Home Assistant profile
+
+3. Add the bundle as a Lovelace resource in Home Assistant (**Settings > Dashboards > ⋮ > Resources > + Add Resource**)
+    ```
+    http://localhost:5000/valetudo-map-card.js
+    ```
+
 ## License
 
 Lovelace Valetudo Map Card is licensed under the MIT license.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "rollup-plugin-babel": "4.4.0",
         "rollup-plugin-commonjs": "10.1.0",
         "rollup-plugin-node-resolve": "5.2.0",
+        "rollup-plugin-serve": "1.1.1",
         "rollup-plugin-terser": "7.0.2",
         "rollup-plugin-typescript2": "0.33.0",
         "typescript": "4.8.2"
@@ -2362,6 +2363,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2400,6 +2413,15 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -2746,6 +2768,16 @@
       },
       "peerDependencies": {
         "rollup": ">=1.11.0"
+      }
+    },
+    "node_modules/rollup-plugin-serve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-1.1.1.tgz",
+      "integrity": "sha512-H0VarZRtFR0lfiiC9/P8jzCDvtFf1liOX4oSdIeeYqUCKrmFA7vNiQ0rg2D+TuoP7leaa/LBR8XBts5viF6lnw==",
+      "dev": true,
+      "dependencies": {
+        "mime": "^2",
+        "opener": "1"
       }
     },
     "node_modules/rollup-plugin-terser": {
@@ -4952,6 +4984,12 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4988,6 +5026,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -5227,6 +5271,16 @@
         "is-module": "^1.0.0",
         "resolve": "^1.11.1",
         "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-serve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-1.1.1.tgz",
+      "integrity": "sha512-H0VarZRtFR0lfiiC9/P8jzCDvtFf1liOX4oSdIeeYqUCKrmFA7vNiQ0rg2D+TuoP7leaa/LBR8XBts5viF6lnw==",
+      "dev": true,
+      "requires": {
+        "mime": "^2",
+        "opener": "1"
       }
     },
     "rollup-plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint -c .automated.eslintrc.json .",
     "lint_fix": "eslint -c .automated.eslintrc.json . --fix",
 
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "dev": "rollup -c -w"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-terser": "7.0.2",
     "rollup-plugin-typescript2": "0.33.0",
+    "rollup-plugin-serve": "1.1.1",
     "typescript": "4.8.2",
     "@rollup/plugin-json": "4.1.0",
     "babel-plugin-inline-json-import": "0.3.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,19 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import babel from "rollup-plugin-babel";
 import { terser } from "rollup-plugin-terser";
 import json from "@rollup/plugin-json";
+import serve from 'rollup-plugin-serve';
+
+const dev = process.env.ROLLUP_WATCH;
+
+/** @type {import("rollup-plugin-serve").ServeOptions} */
+const serveOpts = {
+    contentBase: ['./dist'],
+    host: '0.0.0.0',
+    port: 5000,
+    headers: {
+        'Access-Control-Allow-Origin': '*'
+    }
+};
 
 const plugins = [
     nodeResolve({}),
@@ -16,7 +29,8 @@ const plugins = [
             ["inline-json-import", {}]
         ]
     }),
-    terser(),
+    dev && serve(serveOpts),
+    !dev && terser(),
 ];
 
 export default [


### PR DESCRIPTION
Hey!

I wasn't sure how to test out this card locally during development, so I added an `npm run dev` command that runs Rollup in watch mode and serves the script at `http://localhost:5000/valetudo-map-card.js`. It's basically copied from the way [custom-cards/boilerplate-card](https://github.com/custom-cards/boilerplate-card/blob/master/rollup.config.js) does it.
